### PR TITLE
Tried to resolve Android's border with issue based on pixel density

### DIFF
--- a/src/Xamarin.Forms.PancakeView.Droid/PancakeViewRenderer.cs
+++ b/src/Xamarin.Forms.PancakeView.Droid/PancakeViewRenderer.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Forms.PancakeView.Droid
                 UpdateBackground();
 
                 // Clips the content to the box we provide.
-                this.OutlineProvider = new RoundedCornerOutlineProvider(pancake.CornerRadius, pancake.BorderThickness * 4);
+                this.OutlineProvider = new RoundedCornerOutlineProvider(pancake.CornerRadius, (int)Context.ToPixels(pancake.BorderThickness));
                 this.ClipToOutline = true;
 
                 // If it has a shadow, give it a default Droid looking shadow.
@@ -217,13 +217,15 @@ namespace Xamarin.Forms.PancakeView.Droid
 
             void DrawOutline(ACanvas canvas, int width, int height, Thickness cornerRadius)
             {
-                // TODO: This doesn't look entirely right yet when using it with rounded corners.
+                var borderThickness = _convertToPixels(_pancake.BorderThickness);
+                var halfBorderThickness = borderThickness / 2;
 
+                // TODO: This doesn't look entirely right yet when using it with rounded corners.
                 using (var paint = new Paint { AntiAlias = true })
                 using (var path = new Path())
                 using (Path.Direction direction = Path.Direction.Cw)
                 using (Paint.Style style = Paint.Style.Stroke)
-                using (var rect = new RectF(0 + _pancake.BorderThickness, 0 + _pancake.BorderThickness, width - _pancake.BorderThickness, height - _pancake.BorderThickness))
+                using (var rect = new RectF(halfBorderThickness, halfBorderThickness, width - halfBorderThickness, height - halfBorderThickness))
                 {
                     float topLeft = _convertToPixels(cornerRadius.Left);
                     float topRight = _convertToPixels(cornerRadius.Top);
@@ -232,13 +234,13 @@ namespace Xamarin.Forms.PancakeView.Droid
 
                     path.AddRoundRect(rect, new float[] { topLeft, topLeft, topRight, topRight, bottomRight, bottomRight, bottomLeft, bottomLeft }, direction);
 
-                    if(_pancake.BorderIsDashed)
+                    if (_pancake.BorderIsDashed)
                     {
                         paint.SetPathEffect(new DashPathEffect(new float[] { 10, 20 }, 0));
                     }
 
                     paint.StrokeCap = Paint.Cap.Round;
-                    paint.StrokeWidth = _pancake.BorderThickness;
+                    paint.StrokeWidth = borderThickness;
                     paint.SetStyle(style);
                     paint.Color = _pancake.BorderColor.ToAndroid();
 


### PR DESCRIPTION
PR to try to fix https://github.com/sthewissen/Xamarin.Forms.PancakeView/issues/4

Main changes are :
- Properly use a Real Pixel Ratio (in DP) to evaluate the proper Android BorderThickness value. Won't give a 1:1 ratio with iOS, but it's progress :)

- Adjust position and measurements of the Outline, by using half the value of the BorderThickness.
I haven't checked in the Android documentation the logic used to position the Outline X and Y positions, but doing so makes sure the outline is properly aligned with the previously generated background in the canvas.

This PR applied to the samples projects produces this:

![screenshot 2019-02-14 at 16 29 20](https://user-images.githubusercontent.com/475526/52797523-5ad9ad00-3076-11e9-9267-8876a36cc117.png)


