### PR TITLE
NuGet licence infomation

### DIFF
--- a/src/Xamarin.Forms.PancakeView.Multi/Xamarin.Forms.PancakeView.Multi.csproj
+++ b/src/Xamarin.Forms.PancakeView.Multi/Xamarin.Forms.PancakeView.Multi.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
   	<TargetFrameworks>netstandard2.0;Xamarin.iOS10;MonoAndroid81;MonoAndroid90</TargetFrameworks>
-    
+
     <!--Assembly and Namespace info -->
     <AssemblyName>Xamarin.Forms.PancakeView</AssemblyName>
     <RootNamespace>Xamarin.Forms.PancakeView</RootNamespace>
-    
+
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <AssemblyVersion>1.2.0</AssemblyVersion>
     <AssemblyFileVersion>1.2.0</AssemblyFileVersion>
@@ -15,7 +15,7 @@
     <NeutralLanguage>en</NeutralLanguage>
     <LangVersion>default</LangVersion>
     <DefineConstants>$(DefineConstants);</DefineConstants>
-     
+
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 
@@ -35,22 +35,23 @@
     <Authors>Steven Thewissen</Authors>
     <Copyright>Copyright 2019 Steven Thewissen</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+
   </PropertyGroup>
-  
+
   <!-- Define what happens on build and release -->
    <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition=" '$(Configuration)'=='Release' ">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <DebugType>pdbonly</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Compile Include="Platforms\Shared\**\*.cs" />
 

--- a/src/Xamarin.Forms.PancakeView.Multi/Xamarin.Forms.PancakeView.Multi.csproj
+++ b/src/Xamarin.Forms.PancakeView.Multi/Xamarin.Forms.PancakeView.Multi.csproj
@@ -21,7 +21,6 @@
 
     <LangVersion>latest</LangVersion>
 
-    <PackageLicenseUrl>https://github.com/sthewissen/Xamarin.Forms.PancakeView/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/sthewissen/Xamarin.Forms.PancakeView</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/sthewissen/Xamarin.Forms.PancakeView/master/images/icon.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/sthewissen/Xamarin.Forms.PancakeView</RepositoryUrl>


### PR DESCRIPTION
I added the MIT licence info to the NuGet package information

`<PackageLicenseExpression>MIT</PackageLicenseExpression>`

But in order to do this need to remove the `LicenceUrl` which is being deprecated
Here is a quote from https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets -

> licenseUrl is being deprecated, use the PackageLicenseExpression or PackageLicenseFile property

The reason I  added this is because we have an automated tool that checks all licences but without this added it doesn't know the licence. 


![image](https://user-images.githubusercontent.com/6544051/64053748-a0c21280-cb7b-11e9-915b-c0e31e4542f2.png)

![image](https://user-images.githubusercontent.com/6544051/64053765-bdf6e100-cb7b-11e9-8568-296a7ce9a5ee.png)
