### PR TITLE
[WIP] iOS border updates: BorderEdges, BorderThickness, BorderDrawingStyle.

### DIFF
--- a/src/Xamarin.Forms.PancakeView.Multi/Platforms/Android/PancakeViewRenderer.cs
+++ b/src/Xamarin.Forms.PancakeView.Multi/Platforms/Android/PancakeViewRenderer.cs
@@ -235,9 +235,9 @@ namespace Xamarin.Forms.PancakeView.Droid
 
         private void DrawBorder(ACanvas canvas, PancakeView control)
         {
-            if (control.BorderThickness > 0)
+            if (control.BorderThickness != default)
             {
-                var borderThickness = Context.ToPixels(control.BorderThickness);
+                var borderThickness = Context.ToPixels(control.BorderThickness.Left);
                 var halfBorderThickness = borderThickness / 2;
                 bool hasShadowOrElevation = control.HasShadow || (Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop && control.Elevation > 0);
 
@@ -268,7 +268,7 @@ namespace Xamarin.Forms.PancakeView.Droid
                     {
                         // dashes merge when thickness is increased
                         // off-distance should be scaled according to thickness
-                        paint.SetPathEffect(new DashPathEffect(new float[] { 10, 5 * control.BorderThickness }, 0));
+                        paint.SetPathEffect(new DashPathEffect(new float[] { 10, 5 * (float)control.BorderThickness.Left }, 0));
                     }
 
                     if ((control.BorderGradientStartColor != default(Color) && control.BorderGradientEndColor != default(Color)) || (control.BorderGradientStops != null && control.BorderGradientStops.Any()))

--- a/src/Xamarin.Forms.PancakeView.Multi/Platforms/Shared/BorderDrawingStyle.cs
+++ b/src/Xamarin.Forms.PancakeView.Multi/Platforms/Shared/BorderDrawingStyle.cs
@@ -3,6 +3,7 @@
     public enum BorderDrawingStyle
     {
         Inside,
-        Outside
+        Outside,
+        Centered
     }
 }

--- a/src/Xamarin.Forms.PancakeView.Multi/Platforms/Shared/BorderEdge.cs
+++ b/src/Xamarin.Forms.PancakeView.Multi/Platforms/Shared/BorderEdge.cs
@@ -1,0 +1,14 @@
+﻿using System;
+namespace Xamarin.Forms.PancakeView.Platforms.Shared
+{
+    [Flags]
+    public enum Edge
+    {
+        None = 0,
+        Left = 1,
+        Top = 2,
+        Right = 4,
+        Bottom = 8,
+        All = Left | Top | Right | Bottom
+    }
+}

--- a/src/Xamarin.Forms.PancakeView.Multi/Platforms/Shared/PancakeView.cs
+++ b/src/Xamarin.Forms.PancakeView.Multi/Platforms/Shared/PancakeView.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
+using Xamarin.Forms.PancakeView.Platforms.Shared;
 
 namespace Xamarin.Forms.PancakeView
 {
@@ -13,7 +12,15 @@ namespace Xamarin.Forms.PancakeView
         public static readonly BindableProperty HasShadowProperty = BindableProperty.Create(nameof(HasShadow), typeof(bool), typeof(PancakeView), default(bool));
         public static readonly BindableProperty ElevationProperty = BindableProperty.Create(nameof(Elevation), typeof(int), typeof(PancakeView), 0);
 
-        public static readonly BindableProperty BorderThicknessProperty = BindableProperty.Create(nameof(BorderThickness), typeof(float), typeof(PancakeView), default(float));
+
+        public static readonly BindableProperty BorderEdgesProperty = BindableProperty.Create(
+            propertyName: nameof(BorderEdges),
+            returnType: typeof(Edge),
+            declaringType: typeof(PancakeView),
+            defaultValue: Edge.All
+            );
+
+        public static readonly BindableProperty BorderThicknessProperty = BindableProperty.Create(nameof(BorderThickness), typeof(Thickness), typeof(PancakeView), default(Thickness));
         public static readonly BindableProperty BorderIsDashedProperty = BindableProperty.Create(nameof(BorderIsDashed), typeof(bool), typeof(PancakeView), default(bool));
         public static readonly BindableProperty BorderColorProperty = BindableProperty.Create(nameof(BorderColor), typeof(Color), typeof(PancakeView), default(Color));
         public static readonly BindableProperty BorderDrawingStyleProperty = BindableProperty.Create(nameof(BorderDrawingStyle), typeof(BorderDrawingStyle), typeof(PancakeView), defaultValue: BorderDrawingStyle.Inside);
@@ -39,6 +46,12 @@ namespace Xamarin.Forms.PancakeView
         });
 
         public static readonly BindableProperty OffsetAngleProperty = BindableProperty.Create(nameof(OffsetAngle), typeof(double), typeof(PancakeView), default(double));
+
+        public Edge BorderEdges
+        {
+            get => (Edge)GetValue(BorderEdgesProperty);
+            set => SetValue(BorderEdgesProperty, value);
+        }
 
         public int Sides
         {
@@ -100,9 +113,9 @@ namespace Xamarin.Forms.PancakeView
             set { SetValue(CornerRadiusProperty, value); }
         }
 
-        public float BorderThickness
+        public Thickness BorderThickness
         {
-            get { return (float)GetValue(BorderThicknessProperty); }
+            get { return (Thickness)GetValue(BorderThicknessProperty); }
             set { SetValue(BorderThicknessProperty, value); }
         }
 

--- a/src/Xamarin.Forms.PancakeView.Multi/Platforms/UWP/PancakeViewRenderer.cs
+++ b/src/Xamarin.Forms.PancakeView.Multi/Platforms/UWP/PancakeViewRenderer.cs
@@ -12,20 +12,12 @@ using Xamarin.Forms.Platform.UWP;
 using Controls = Xamarin.Forms.PancakeView;
 using System.Numerics;
 using Windows.UI.Xaml.Hosting;
-using Windows.UI.Composition;
 
 [assembly: ExportRenderer(typeof(Controls.PancakeView), typeof(PancakeViewRenderer))]
 namespace Xamarin.Forms.PancakeView.UWP
 {
-    public class PancakeViewRenderer : ViewRenderer<PancakeView, Windows.UI.Xaml.Controls.Border>
+    public class PancakeViewRenderer : ViewRenderer<PancakeView, Border>
     {
-        //create the shadow effect 
-        private Windows.UI.Xaml.Shapes.Rectangle rectangle = new Windows.UI.Xaml.Shapes.Rectangle { Fill = new SolidColorBrush(Windows.UI.Colors.Transparent) };
-        private Windows.UI.Xaml.Controls.Grid container;
-        private Border content;
-        private SpriteVisual visual;
-
-
         /// <summary>
         /// This method ensures that we don't get stripped out by the linker.
         /// </summary>
@@ -60,7 +52,7 @@ namespace Xamarin.Forms.PancakeView.UWP
             if (e.NewElement != null)
             {
                 if (Control == null)
-                    SetNativeControl(new Windows.UI.Xaml.Controls.Border());
+                    SetNativeControl(new Border());
 
                 var pancake = (Element as PancakeView);
 
@@ -78,23 +70,15 @@ namespace Xamarin.Forms.PancakeView.UWP
                 UpdateShadow(pancake);
             }
         }
-
+        
         void PackChild()
         {
-            container = new Windows.UI.Xaml.Controls.Grid { HorizontalAlignment = Control.HorizontalAlignment, VerticalAlignment = Control.VerticalAlignment };
-            content = new Border { HorizontalAlignment = Control.HorizontalAlignment, VerticalAlignment = Control.VerticalAlignment };
+            if (Element.Content == null)
+                return;
 
-            if (Element.Content != null)
-            {
-                IVisualElementRenderer renderer = Element.Content.GetOrCreateRenderer();
-                content.Child = (renderer.ContainerElement);
-            }
-
-            container.Children.Add(rectangle);
-            container.Children.Add(content);
-            Control.Child = (container);
+            IVisualElementRenderer renderer = Element.Content.GetOrCreateRenderer();
+            Control.Child = renderer.ContainerElement;
         }
-
 
         protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
@@ -110,21 +94,20 @@ namespace Xamarin.Forms.PancakeView.UWP
             else if (e.PropertyName == PancakeView.CornerRadiusProperty.PropertyName)
             {
                 UpdateCornerRadius(pancake);
-                UpdateShadow(pancake);
             }
             else if (e.PropertyName == PancakeView.HasShadowProperty.PropertyName ||
                 e.PropertyName == PancakeView.ElevationProperty.PropertyName)
             {
                 UpdateShadow(pancake);
             }
-            else if (e.PropertyName == PancakeView.BackgroundGradientAngleProperty.PropertyName ||
+            else if(e.PropertyName == PancakeView.BackgroundGradientAngleProperty.PropertyName ||
                 e.PropertyName == PancakeView.BackgroundGradientStartColorProperty.PropertyName ||
                 e.PropertyName == PancakeView.BackgroundGradientEndColorProperty.PropertyName ||
                 e.PropertyName == PancakeView.BackgroundGradientStopsProperty.PropertyName)
             {
                 UpdateBackgroundColor();
             }
-            else if (e.PropertyName == PancakeView.BorderGradientAngleProperty.PropertyName ||
+            else if(e.PropertyName == PancakeView.BorderGradientAngleProperty.PropertyName ||
                 e.PropertyName == PancakeView.BorderGradientStartColorProperty.PropertyName ||
                 e.PropertyName == PancakeView.BorderGradientEndColorProperty.PropertyName ||
                 e.PropertyName == PancakeView.BorderGradientStopsProperty.PropertyName ||
@@ -134,69 +117,30 @@ namespace Xamarin.Forms.PancakeView.UWP
             {
                 UpdateBorder(pancake);
             }
-
-            else if (e.PropertyName == PancakeView.WidthProperty.PropertyName ||
-                    e.PropertyName == PancakeView.HeightProperty.PropertyName)
-            {
-                UpdateShadow(pancake);
-            }
         }
 
         private void UpdateShadow(PancakeView pancake)
         {
-            //For now gets the shadow only when the CornerRadius has the same value for all sides. 
-            if (Control != null && pancake.HasShadow && pancake.Width > 0 && pancake.Height > 0 &&
-                pancake.CornerRadius.TopLeft == pancake.CornerRadius.BottomRight &&
-                pancake.CornerRadius.TopLeft == pancake.CornerRadius.BottomLeft &&
-                pancake.CornerRadius.BottomRight == pancake.CornerRadius.TopRight)
+            if (Control != null)
             {
-                rectangle.Fill = new SolidColorBrush(Windows.UI.Colors.Black);
-                rectangle.Width = pancake.Width;
-                rectangle.Height = pancake.Height;
-                rectangle.RadiusX = pancake.CornerRadius.TopRight + 5;
-                rectangle.RadiusY = pancake.CornerRadius.TopRight + 5;
 
-                var compositor = ElementCompositionPreview.GetElementVisual(rectangle).Compositor;
-                visual = compositor.CreateSpriteVisual();
-                visual.Size = new Vector2((float)pancake.Width, (float)pancake.Height);           
-
-                var shadow = compositor.CreateDropShadow();
-                shadow.BlurRadius = 30f;
-                shadow.Mask = rectangle.GetAlphaMask();
-                shadow.Opacity = 0.75f;
-                visual.Shadow = shadow;
-
-                ElementCompositionPreview.SetElementChildVisual(rectangle, visual);
-            }
-            else
-            {
-                if (rectangle != null)
-                {
-                    rectangle.Fill = new SolidColorBrush(Windows.UI.Colors.Transparent);
-                }
-
-                if (visual != null)
-                {
-                    visual.Shadow = null;
-                    ElementCompositionPreview.SetElementChildVisual(rectangle, null);
-                }
             }
         }
 
         private void UpdateCornerRadius(PancakeView pancake)
         {
-            if (content != null)
+            if(Control!= null)
             {
-                this.content.CornerRadius = new Windows.UI.Xaml.CornerRadius(pancake.CornerRadius.TopLeft, pancake.CornerRadius.TopRight, pancake.CornerRadius.BottomRight, pancake.CornerRadius.BottomLeft);
+                this.Control.CornerRadius = new Windows.UI.Xaml.CornerRadius(pancake.CornerRadius.TopLeft, pancake.CornerRadius.TopRight, pancake.CornerRadius.BottomRight, pancake.CornerRadius.BottomLeft);
             }
         }
 
         private void UpdateBorder(PancakeView pancake)
         {
             //// Create the border layer
-            if (content != null)
+            if (Control != null)
             {
-                this.content.BorderThickness = new Windows.UI.Xaml.Thickness(pancake.BorderThickness);
+                this.Control.BorderThickness = new Windows.UI.Xaml.Thickness(pancake.BorderThickness);
 
                 if ((pancake.BorderGradientStartColor != default(Color) && pancake.BorderGradientEndColor != default(Color)) || (pancake.BorderGradientStops != null && pancake.BorderGradientStops.Any()))
                 {
@@ -210,19 +154,19 @@ namespace Xamarin.Forms.PancakeView.UWP
                         foreach (var item in orderedStops)
                             gc.Add(new Windows.UI.Xaml.Media.GradientStop { Offset = item.Offset, Color = item.Color.ToWindowsColor() });
 
-                        this.content.BorderBrush = new LinearGradientBrush(gc, pancake.BorderGradientAngle);
+                        this.Control.BorderBrush = new LinearGradientBrush(gc, pancake.BorderGradientAngle);
                     }
                     else
                     {
                         var gs1 = new Windows.UI.Xaml.Media.GradientStop { Offset = 0, Color = pancake.BorderGradientStartColor.ToWindowsColor() };
                         var gs2 = new Windows.UI.Xaml.Media.GradientStop { Offset = 1, Color = pancake.BorderGradientEndColor.ToWindowsColor() };
                         var gc = new Windows.UI.Xaml.Media.GradientStopCollection { gs1, gs2 };
-                        this.content.BorderBrush = new LinearGradientBrush(gc, pancake.BorderGradientAngle);
+                        this.Control.BorderBrush = new LinearGradientBrush(gc, pancake.BorderGradientAngle);
                     }
                 }
                 else
                 {
-                    this.content.BorderBrush = pancake.BorderColor.IsDefault ? null : pancake.BorderColor.ToBrush();
+                    this.Control.BorderBrush = pancake.BorderColor.IsDefault ? null : pancake.BorderColor.ToBrush();
                 }
             }
         }
@@ -234,7 +178,7 @@ namespace Xamarin.Forms.PancakeView.UWP
             // as the background would be applied to the renderer's FrameworkElement
             var pancake = (PancakeView)Element;
 
-            if (content != null)
+            if (Control != null)
             {
                 if ((pancake.BackgroundGradientStartColor != default(Color) && pancake.BackgroundGradientEndColor != default(Color)) || (pancake.BackgroundGradientStops != null && pancake.BackgroundGradientStops.Any()))
                 {
@@ -248,19 +192,19 @@ namespace Xamarin.Forms.PancakeView.UWP
                         foreach (var item in orderedStops)
                             gc.Add(new Windows.UI.Xaml.Media.GradientStop { Offset = item.Offset, Color = item.Color.ToWindowsColor() });
 
-                        this.content.Background = new LinearGradientBrush(gc, pancake.BackgroundGradientAngle);
+                        this.Control.Background = new LinearGradientBrush(gc, pancake.BackgroundGradientAngle);
                     }
                     else
                     {
                         var gs1 = new Windows.UI.Xaml.Media.GradientStop { Offset = 0, Color = pancake.BackgroundGradientStartColor.ToWindowsColor() };
                         var gs2 = new Windows.UI.Xaml.Media.GradientStop { Offset = 1, Color = pancake.BackgroundGradientEndColor.ToWindowsColor() };
                         var gc = new Windows.UI.Xaml.Media.GradientStopCollection { gs1, gs2 };
-                        this.content.Background = new LinearGradientBrush(gc, pancake.BackgroundGradientAngle);
+                        this.Control.Background = new LinearGradientBrush(gc, pancake.BackgroundGradientAngle);
                     }
                 }
                 else
                 {
-                    content.Background = Element.BackgroundColor.IsDefault ? null : Element.BackgroundColor.ToBrush();
+                    Control.Background = Element.BackgroundColor.IsDefault ? null : Element.BackgroundColor.ToBrush();
                 }
             }
         }

--- a/src/Xamarin.Forms.PancakeView.Multi/Platforms/iOS/PancakeViewRenderer.cs
+++ b/src/Xamarin.Forms.PancakeView.Multi/Platforms/iOS/PancakeViewRenderer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
@@ -8,8 +8,10 @@ using Foundation;
 using UIKit;
 using Xamarin.Forms;
 using Xamarin.Forms.PancakeView.iOS;
+using Xamarin.Forms.PancakeView.Platforms.Shared;
 using Xamarin.Forms.Platform.iOS;
 using Controls = Xamarin.Forms.PancakeView;
+using EnumsNET;
 
 [assembly: ExportRenderer(typeof(Controls.PancakeView), typeof(PancakeViewRenderer))]
 namespace Xamarin.Forms.PancakeView.iOS
@@ -91,7 +93,8 @@ namespace Xamarin.Forms.PancakeView.iOS
                     (e.PropertyName == PancakeView.BorderGradientStartColorProperty.PropertyName) ||
                     (e.PropertyName == PancakeView.BorderGradientStopsProperty.PropertyName) ||
                     (e.PropertyName == PancakeView.BorderIsDashedProperty.PropertyName) ||
-                    (e.PropertyName == PancakeView.BorderThicknessProperty.PropertyName))
+                    (e.PropertyName == PancakeView.BorderThicknessProperty.PropertyName) ||
+                    (e.PropertyName == PancakeView.BorderEdgesProperty.PropertyName))
             {
                 DrawBorder();
             }
@@ -103,7 +106,9 @@ namespace Xamarin.Forms.PancakeView.iOS
                     (e.PropertyName == PancakeView.OffsetAngleProperty.PropertyName) ||
                     (e.PropertyName == PancakeView.HasShadowProperty.PropertyName) ||
                     (e.PropertyName == PancakeView.ElevationProperty.PropertyName) ||
-                    (e.PropertyName == PancakeView.SidesProperty.PropertyName))
+                    (e.PropertyName == PancakeView.SidesProperty.PropertyName) ||
+                    (e.PropertyName == PancakeView.BorderThicknessProperty.PropertyName) ||
+                    (e.PropertyName == PancakeView.BorderEdgesProperty.PropertyName))
             {
                 SetNeedsDisplay();
             }
@@ -244,6 +249,91 @@ namespace Xamarin.Forms.PancakeView.iOS
 
         private void DrawBorder()
         {
+            // TODO: remove
+            DrawMultiPathBorder();
+            return;
+
+            //var pancake = Element as PancakeView;
+            //var layerName = "borderLayer";
+
+            //// remove previous background layer if any
+            //var prevBorderLayer = _wrapperView.Layer.Sublayers?.FirstOrDefault(x => x.Name == layerName);
+            //prevBorderLayer?.RemoveFromSuperLayer();
+
+            //if (pancake.BorderThickness > 0)
+            //{
+            //    var borderLayer = new CAShapeLayer
+            //    {
+            //        StrokeColor = pancake.BorderColor == Color.Default ? UIColor.Clear.CGColor : pancake.BorderColor.ToCGColor(),
+            //        FillColor = null,
+            //        LineWidth = pancake.BorderThickness,
+            //        Name = layerName
+            //    };
+
+            //    // Create arcs for the given corner radius.
+            //    bool hasShadowOrElevation = pancake.HasShadow || pancake.Elevation > 0;
+
+            //    borderLayer.Path = pancake.Sides != 4 ?
+            //        ShapeUtils.CreatePolygonPath(Bounds, pancake.Sides, pancake.CornerRadius.TopLeft, pancake.OffsetAngle).CGPath :
+            //        ShapeUtils.CreateRoundedRectPath(Bounds, pancake.CornerRadius).CGPath; // insetBounds?
+
+            //    var layerPosition = new CGPoint(borderLayer.Path.BoundingBox.Width / 2, borderLayer.Path.BoundingBox.Height / 2);
+
+            //    borderLayer.Frame = borderLayer.Path.BoundingBox;
+            //    borderLayer.Position = layerPosition;
+
+            //    // Dash pattern for the border.
+            //    if (pancake.BorderIsDashed)
+            //    {
+            //        borderLayer.LineDashPattern = new NSNumber[] { new NSNumber(6), new NSNumber(3) };
+            //    }
+
+            //    if ((pancake.BorderGradientStartColor != default(Color) && pancake.BorderGradientEndColor != default(Color)) || (pancake.BorderGradientStops != null && pancake.BorderGradientStops.Any()))
+            //    {
+            //        var gradientFrame = Bounds.Inset(-pancake.BorderThickness, -pancake.BorderThickness);
+            //        var gradientLayer = CreateGradientLayer(pancake.BorderGradientAngle, gradientFrame);
+            //        gradientLayer.Position = new CGPoint((gradientFrame.Width / 2) - (pancake.BorderThickness), (gradientFrame.Height / 2) - (pancake.BorderThickness));
+
+            //        // Create a clone from the border layer and use that one as the mask.
+            //        // Why? Because the mask and the border somehow can't be the same, so
+            //        // don't want to do adjustments to borderLayer because it would influence the border.
+            //        var maskLayer = new CAShapeLayer()
+            //        {
+            //            Path = borderLayer.Path,
+            //            Position = new CGPoint(pancake.BorderThickness, pancake.BorderThickness),
+            //            FillColor = null,
+            //            LineWidth = pancake.BorderThickness,
+            //            StrokeColor = UIColor.Red.CGColor,
+            //            LineDashPattern = borderLayer.LineDashPattern
+            //        };
+
+            //        gradientLayer.Mask = maskLayer;
+            //        gradientLayer.Name = layerName;
+
+            //        if (pancake.BorderGradientStops != null && pancake.BorderGradientStops.Count > 0)
+            //        {
+            //            // A range of colors is given. Let's add them.
+            //            var orderedStops = pancake.BorderGradientStops.OrderBy(x => x.Offset).ToList();
+            //            gradientLayer.Colors = orderedStops.Select(x => x.Color.ToCGColor()).ToArray();
+            //            gradientLayer.Locations = orderedStops.Select(x => new NSNumber(x.Offset)).ToArray();
+            //        }
+            //        else
+            //        {
+            //            // Only two colors provided, use that.
+            //            gradientLayer.Colors = new CGColor[] { pancake.BorderGradientStartColor.ToCGColor(), pancake.BorderGradientEndColor.ToCGColor() };
+            //        }
+
+            //        AddLayer(gradientLayer, -1, _wrapperView);
+            //    }
+            //    else
+            //    {
+            //        AddLayer(borderLayer, -1, _wrapperView);
+            //    }
+            //}
+        }
+
+        private void DrawMultiPathBorder()
+        {
             var pancake = Element as PancakeView;
             var layerName = "borderLayer";
 
@@ -251,76 +341,39 @@ namespace Xamarin.Forms.PancakeView.iOS
             var prevBorderLayer = _wrapperView.Layer.Sublayers?.FirstOrDefault(x => x.Name == layerName);
             prevBorderLayer?.RemoveFromSuperLayer();
 
-            if (pancake.BorderThickness > 0)
+            if (pancake.BorderEdges != Edge.None && pancake.BorderThickness != default)    
             {
-                var borderLayer = new CAShapeLayer
+                var thickness = pancake.BorderThickness;
+                var edges = pancake.BorderEdges;
+
+                if (edges.HasAnyFlags(Edge.Left))
                 {
-                    StrokeColor = pancake.BorderColor == Color.Default ? UIColor.Clear.CGColor : pancake.BorderColor.ToCGColor(),
-                    FillColor = null,
-                    LineWidth = pancake.BorderThickness,
-                    Name = layerName
-                };
-
-                // Create arcs for the given corner radius.
-                bool hasShadowOrElevation = pancake.HasShadow || pancake.Elevation > 0;
-
-                borderLayer.Path = pancake.Sides != 4 ?
-                    ShapeUtils.CreatePolygonPath(Bounds, pancake.Sides, pancake.CornerRadius.TopLeft, pancake.OffsetAngle).CGPath :
-                    ShapeUtils.CreateRoundedRectPath(Bounds, pancake.CornerRadius).CGPath; // insetBounds?
-
-                var layerPosition = new CGPoint(borderLayer.Path.BoundingBox.Width / 2, borderLayer.Path.BoundingBox.Height / 2);
-
-                borderLayer.Frame = borderLayer.Path.BoundingBox;
-                borderLayer.Position = layerPosition;
-
-                // Dash pattern for the border.
-                if (pancake.BorderIsDashed)
-                {
-                    borderLayer.LineDashPattern = new NSNumber[] { new NSNumber(6), new NSNumber(3) };
+                    AddEdgeLayer(UIRectEdge.Left, thickness.Left);
                 }
-
-                if ((pancake.BorderGradientStartColor != default(Color) && pancake.BorderGradientEndColor != default(Color)) || (pancake.BorderGradientStops != null && pancake.BorderGradientStops.Any()))
+                if (edges.HasAnyFlags(Edge.Top))
                 {
-                    var gradientFrame = Bounds.Inset(-pancake.BorderThickness, -pancake.BorderThickness);
-                    var gradientLayer = CreateGradientLayer(pancake.BorderGradientAngle, gradientFrame);
-                    gradientLayer.Position = new CGPoint((gradientFrame.Width / 2) - (pancake.BorderThickness), (gradientFrame.Height / 2) - (pancake.BorderThickness));
-
-                    // Create a clone from the border layer and use that one as the mask.
-                    // Why? Because the mask and the border somehow can't be the same, so
-                    // don't want to do adjustments to borderLayer because it would influence the border.
-                    var maskLayer = new CAShapeLayer()
-                    {
-                        Path = borderLayer.Path,
-                        Position = new CGPoint(pancake.BorderThickness, pancake.BorderThickness),
-                        FillColor = null,
-                        LineWidth = pancake.BorderThickness,
-                        StrokeColor = UIColor.Red.CGColor,
-                        LineDashPattern = borderLayer.LineDashPattern
-                    };
-
-                    gradientLayer.Mask = maskLayer;
-                    gradientLayer.Name = layerName;
-
-                    if (pancake.BorderGradientStops != null && pancake.BorderGradientStops.Count > 0)
-                    {
-                        // A range of colors is given. Let's add them.
-                        var orderedStops = pancake.BorderGradientStops.OrderBy(x => x.Offset).ToList();
-                        gradientLayer.Colors = orderedStops.Select(x => x.Color.ToCGColor()).ToArray();
-                        gradientLayer.Locations = orderedStops.Select(x => new NSNumber(x.Offset)).ToArray();
-                    }
-                    else
-                    {
-                        // Only two colors provided, use that.
-                        gradientLayer.Colors = new CGColor[] { pancake.BorderGradientStartColor.ToCGColor(), pancake.BorderGradientEndColor.ToCGColor() };
-                    }
-
-                    AddLayer(gradientLayer, -1, _wrapperView);
+                    AddEdgeLayer(UIRectEdge.Top, thickness.Top);
                 }
-                else
+                if (edges.HasAnyFlags(Edge.Right))
                 {
-                    AddLayer(borderLayer, -1, _wrapperView);
+                    AddEdgeLayer(UIRectEdge.Right, thickness.Right);
+                }
+                if (edges.HasAnyFlags(Edge.Bottom))
+                {
+                    AddEdgeLayer(UIRectEdge.Bottom, thickness.Bottom);
                 }
             }
+        }
+
+        void AddEdgeLayer(UIRectEdge edge, double thickness)
+        {
+            var pancake = Element as PancakeView;
+
+            var strokeColor = pancake.BorderColor.ToCGColor();
+            var lineWidth = thickness;
+            var borderDrawingStyle = pancake.BorderDrawingStyle;
+
+            AddLayer(Bounds.ToEdgeLayer(edge, strokeColor, lineWidth, pancake.CornerRadius, borderDrawingStyle), -1, _wrapperView);
         }
 
         private void DrawShadow()

--- a/src/Xamarin.Forms.PancakeView.Multi/Platforms/iOS/ShapeUtils.cs
+++ b/src/Xamarin.Forms.PancakeView.Multi/Platforms/iOS/ShapeUtils.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using CoreAnimation;
 using CoreGraphics;
 using UIKit;
 
@@ -6,20 +7,182 @@ namespace Xamarin.Forms.PancakeView.iOS
 {
     public static class ShapeUtils
     {
+        public static CGPoint BottomLeft(this CGRect rect) => new CGPoint(x: rect.Left, y: rect.Bottom);
+        public static CGPoint BottomRight(this CGRect rect) => new CGPoint(x: rect.Right, y: rect.Bottom);
+        public static CGPoint TopLeft(this CGRect rect) => new CGPoint(x: rect.Left, y: rect.Top);
+        public static CGPoint TopRight(this CGRect rect) => new CGPoint(x: rect.Right, y: rect.Top);
+
+        public static CGPoint OffsetBy(this CGPoint point, float x, float y)
+        {
+            point.X += x;
+            point.Y += y;
+            return point;
+        }
+
+        public static CGPoint OffsetBy(this CGPoint point, double x, double y)
+        {
+            point.X += (float)x;
+            point.Y += (float)y;
+            return point;
+        }
+
         public static UIBezierPath CreateRoundedRectPath(CGRect rect, CornerRadius cornerRadius)
         {
             var path = new UIBezierPath();
 
-            path.MoveTo(new CGPoint(rect.Width - cornerRadius.TopRight, rect.Y));
-            path.AddArc(new CGPoint((float)rect.X + rect.Width - cornerRadius.TopRight, (float)rect.Y + cornerRadius.TopRight), (nfloat)cornerRadius.TopRight, (float)(Math.PI * 1.5), (float)Math.PI * 2, true);
+            path.MoveTo(
+                new CGPoint(
+                    rect.Width - cornerRadius.TopRight,
+                    rect.Y));
+
+            path.AddArc(
+                center: new CGPoint(
+                    rect.Width - cornerRadius.TopRight,
+                    cornerRadius.TopRight),
+                radius: (nfloat)cornerRadius.TopRight,
+                startAngle: (float)(Math.PI * 1.5),
+                endAngle: (float)Math.PI * 2,
+                clockWise: true);
+
             path.AddLineTo(new CGPoint(rect.Width, rect.Height - cornerRadius.BottomRight));
-            path.AddArc(new CGPoint((float)rect.X + rect.Width - cornerRadius.BottomRight, (float)rect.Y + rect.Height - cornerRadius.BottomRight), (nfloat)cornerRadius.BottomRight, 0, (float)(Math.PI * .5), true);
+            path.AddArc(
+                new CGPoint((float)rect.X + rect.Width - cornerRadius.BottomRight,
+                (float)rect.Y + rect.Height - cornerRadius.BottomRight),
+                (nfloat)cornerRadius.BottomRight,
+                0,
+                (float)(Math.PI * .5), true);
             path.AddLineTo(new CGPoint(cornerRadius.BottomLeft, rect.Height));
             path.AddArc(new CGPoint((float)rect.X + cornerRadius.BottomLeft, (float)rect.Y + rect.Height - cornerRadius.BottomLeft), (nfloat)cornerRadius.BottomLeft, (float)(Math.PI * .5), (float)Math.PI, true);
             path.AddLineTo(new CGPoint(rect.X, cornerRadius.TopLeft));
             path.AddArc(new CGPoint((float)rect.X + cornerRadius.TopLeft, (float)rect.Y + cornerRadius.TopLeft), (nfloat)cornerRadius.TopLeft, (float)Math.PI, (float)(Math.PI * 1.5), true);
 
             path.ClosePath();
+
+            return path;
+        }
+
+        public static CAShapeLayer ToEdgeLayer(
+            this CGRect rect,
+            UIRectEdge edge,
+            CGColor strokeColor,
+            double lineWidth,
+            CornerRadius cornerRadius = default,
+            BorderDrawingStyle borderStyle = BorderDrawingStyle.Inside)
+        {
+            var edgeLayer = new CAShapeLayer
+            {
+                StrokeColor = strokeColor,
+                FillColor = null,
+                LineWidth = (float)lineWidth,
+            };
+
+            var path = new UIBezierPath();
+
+            switch (edge)
+            {
+                case UIRectEdge.Left:
+                    edgeLayer.Name = "leftEdgeBorderLayer";
+                    path = rect.ToEdgePath(edge, lineWidth, cornerRadius, borderStyle);
+                    break;
+                case UIRectEdge.Top:
+                    edgeLayer.Name = "topEdgeBorderLayer";
+                    path = rect.ToEdgePath(edge, lineWidth, cornerRadius, borderStyle);
+                    break;
+                case UIRectEdge.Right:
+                    edgeLayer.Name = "rightEdgeBorderLayer";
+                    path = rect.ToEdgePath(edge, lineWidth, cornerRadius, borderStyle);
+                    break;
+                case UIRectEdge.Bottom:
+                    edgeLayer.Name = "bottomEdgeBorderLayer";
+                    path = rect.ToEdgePath(edge, lineWidth, cornerRadius, borderStyle);
+                    break;
+            }
+
+            edgeLayer.Path = path.CGPath;
+            return edgeLayer;
+        }
+
+            public static UIBezierPath ToEdgePath(
+            this CGRect rect,
+            UIRectEdge edge,
+            double lineWidth,
+            CornerRadius cornerRadius = default,
+            BorderDrawingStyle borderStyle = BorderDrawingStyle.Inside)
+        {
+            var halfBorder = (float)(lineWidth / 2);
+            var insetRect =
+                borderStyle switch
+                {
+                    BorderDrawingStyle.Inside => rect.Inset(halfBorder, halfBorder),
+                    BorderDrawingStyle.Outside => rect.Inset(-halfBorder, -halfBorder),
+                    BorderDrawingStyle.Centered => rect,
+                    _ => rect
+                };
+
+            var path = new UIBezierPath();
+
+            switch (edge)
+            {
+                case UIRectEdge.Left:
+                    path.MoveTo(insetRect
+                        .BottomLeft()
+                        .OffsetBy(x: 0, y: halfBorder - cornerRadius.BottomLeft));
+
+                    var topLeft = insetRect
+                        .TopLeft()
+                        .OffsetBy(x: 0, y: -halfBorder + cornerRadius.TopLeft);
+
+                    path.AddLineTo(topLeft);
+
+                    path.AddArc(
+                        center: insetRect
+                            .TopLeft()
+                            .OffsetBy(x: cornerRadius.TopLeft, y: cornerRadius.TopLeft),
+                            //.OffsetBy(x: halfBorder, y: halfBorder),
+                        radius: (nfloat)cornerRadius.TopLeft,
+                        startAngle: (float)Math.PI,
+                        endAngle: (float)(Math.PI * 1.5),
+                        clockWise: true);
+                    break;
+
+                case UIRectEdge.Top:
+                    path.MoveTo(insetRect
+                        .TopLeft()
+                        .OffsetBy(x: -halfBorder + cornerRadius.TopLeft, y: 0));
+
+                    var topRightPoint = insetRect
+                        .TopRight()
+                        .OffsetBy(x: halfBorder - cornerRadius.TopRight, y: 0);
+
+                    path.AddLineTo(topRightPoint);
+
+                    path.AddArc(
+                        center: topRightPoint
+                            .OffsetBy(x: -halfBorder, y: cornerRadius.TopRight),
+                        radius: (nfloat)cornerRadius.TopRight,
+                        startAngle: (float)(Math.PI * 1.5),
+                        endAngle: (float)Math.PI * 2,
+                        clockWise: true);
+                    break;
+
+                case UIRectEdge.Right:
+                    path.MoveTo(insetRect
+                        .TopRight()
+                        .OffsetBy(x: 0, y: -halfBorder + cornerRadius.TopRight));
+                    path.AddLineTo(insetRect
+                        .BottomRight()
+                        .OffsetBy(x: 0, y: halfBorder - cornerRadius.BottomRight));
+                    break;
+
+                case UIRectEdge.Bottom:
+                    path.MoveTo(insetRect
+                        .BottomRight()
+                        .OffsetBy(x: halfBorder - cornerRadius.BottomRight, y: 0));
+                    path.AddLineTo(insetRect
+                        .BottomLeft()
+                        .OffsetBy(x: -halfBorder + cornerRadius.BottomLeft, y: 0));
+                    break;
+            }
 
             return path;
         }

--- a/src/Xamarin.Forms.PancakeView.Multi/Xamarin.Forms.PancakeView.Multi.csproj
+++ b/src/Xamarin.Forms.PancakeView.Multi/Xamarin.Forms.PancakeView.Multi.csproj
@@ -59,6 +59,7 @@
 
     <!--NuGet that bring in good stuff -->
     <PackageReference Include="Xamarin.Forms" Version="3.6.0.220655" />
+    <PackageReference Include="Enums.NET" Version="3.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
@@ -82,5 +83,13 @@
     -->
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="Platforms\Shared\SideOptions.cs">
+      <SubType></SubType>
+    </Compile>
+    <Compile Update="Platforms\Shared\BorderEdge.cs">
+      <SubType></SubType>
+    </Compile>
+  </ItemGroup>
    <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>


### PR DESCRIPTION
Here are some iOS updates that are still a WIP (but pretty close). If you run the app and look at the bordered pancakes, you'll see that each edge is drawn separately and leaves room for the corner arcs. I'm struggling to get the math perfect for filling in the arcs. Have a a look at the top-left and top-right corners. They are _almost_ working but that's not good enough of course. I'm having another look now but decided to submit this PR in case someone wants to help.

Updates are for the following:

- BorderThickness is now of type Thickness so now each side can be of a specified thickness (I wanted this so when they're stacked vertically with no margin so they don't double up).

- BorderEdges can be specified. This could be useful for maybe two-tone info or warning pancakes that just have a thick inside left border. It's an enum (Left, Right, Top, Bottom, All).

- BorderDrawingStyle now works by drawing the borders inside, outside, or centred. Previously they were drawn centred as that is the default for UIBezierPath. This was causing the borders to be clipped for me when stacking pancakes.

If we can figure out the corner fills, then iOS can be finished pretty quickly. Android would need to be updated as well but should be easier to copy from iOS.

