### PR TITLE
Made Color bindable in MarkupExtensions

### DIFF
--- a/src/Xamarin.Forms.PancakeView.Multi/Platforms/Shared/MarkupExtensions/BorderMarkupExtension.cs
+++ b/src/Xamarin.Forms.PancakeView.Multi/Platforms/Shared/MarkupExtensions/BorderMarkupExtension.cs
@@ -4,11 +4,17 @@ using Xamarin.Forms.Xaml;
 namespace Xamarin.Forms.PancakeView
 {
     [AcceptEmptyServiceProvider]
-    public class BorderMarkupExtension : IMarkupExtension<Border>
+    public class BorderMarkupExtension : BindableObject, IMarkupExtension<Border>
     {
+        public static BindableProperty ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(BorderMarkupExtension), DropShadow.ColorProperty.DefaultValue);
+
         public int Thickness { set; get; } = (int)Border.ThicknessProperty.DefaultValue;
 
-        public Color Color { set; get; } = (Color)Border.ColorProperty.DefaultValue;
+        public Color Color
+        {
+            set => SetValue(ColorProperty, value);
+            get => (Color)GetValue(ColorProperty);
+        }
 
         public DashPattern DashPattern { set; get; } = (DashPattern)Border.DashPatternProperty.DefaultValue;
 

--- a/src/Xamarin.Forms.PancakeView.Multi/Platforms/Shared/MarkupExtensions/ShadowMarkupExtension.cs
+++ b/src/Xamarin.Forms.PancakeView.Multi/Platforms/Shared/MarkupExtensions/ShadowMarkupExtension.cs
@@ -4,11 +4,17 @@ using Xamarin.Forms.Xaml;
 namespace Xamarin.Forms.PancakeView
 {
     [AcceptEmptyServiceProvider]
-    public class ShadowMarkupExtension : IMarkupExtension<DropShadow>
+    public class ShadowMarkupExtension : BindableObject, IMarkupExtension<DropShadow>
     {
+        public static BindableProperty ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(ShadowMarkupExtension), DropShadow.ColorProperty.DefaultValue); 
+
         public float BlurRadius { set; get; } = (float)DropShadow.BlurRadiusProperty.DefaultValue;
 
-        public Color Color { set; get; } = (Color)DropShadow.ColorProperty.DefaultValue;
+        public Color Color
+        {
+            set => SetValue(ColorProperty, value);
+            get => (Color)GetValue(ColorProperty);
+        }
 
         public Point Offset { set; get; } = (Point)DropShadow.OffsetProperty.DefaultValue;
 


### PR DESCRIPTION
I made Color bindable in the markup extensions. The reason I want Color to be bindable is that I want to use them together with AppThemeBinding that was introduced in Xamarin.Forms 4.7.

```xaml
<yummy:PancakeView Shadow="{yummy:ShadowMarkup Color={AppThemeBinding Dark=LightGray, Light=DarkGray}}">
```